### PR TITLE
Concurrently route requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ Response with content only.
 }
 ```
 
+### Concurrency
+By default, `multifetch` will process each request sequentially, waiting until a request has been processed and fully piped out before it processes the next request.
+
+If the response to each of your requests is small but takes a long time to fetch (e.g. heavy database queries), `multifetch` supports concurrently processing requests.
+
+Passing `concurrency: N` as an option allows you to control the number of concurrent requests being processed at any one time:
+
+```javascript
+app.get('/api/multifetch', multifetch({concurrency: 5}));
+```
+In the above case, 5 requests would be routed through express concurrently, and the response of each is placed in a queue to be streamed out to the client sequentially.
+
 License
 -------
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "async": "~0.9.0",
     "pump": "~1.0.0",
     "extend": "~2.0.0"
   },

--- a/source/index.js
+++ b/source/index.js
@@ -125,27 +125,25 @@ var create = function(options, prefetch) {
 		// stream into the resource queue.
 		var fetchResource = function(key, callback) {
 			var messages = createMessages(request, query[key]);
-			process.nextTick(function() {
-				prefetch(request, messages.request, function(prevent) {
-					if (prevent) return callback();
+			prefetch(request, messages.request, function(prevent) {
+				if (prevent) return callback();
 
-					var resource = fetch(messages.request, messages.response);
-					var task = {
-						resource: resource,
-						request: messages.request,
-						response: messages.response,
-						key: key
-					};
+				var resource = fetch(messages.request, messages.response);
+				var task = {
+					resource: resource,
+					request: messages.request,
+					response: messages.response,
+					key: key
+				};
 
-					app(messages.request, messages.response, function() {
-						resourceQueue.kill();
-						json.destroy();
-					});
-
-					// Callback is called once the stream for this resource has
-					// been fully piped out to the client.
-					resourceQueue.push(task, callback);
+				app(messages.request, messages.response, function() {
+					resourceQueue.kill();
+					json.destroy();
 				});
+
+				// Callback is called once the stream for this resource has
+				// been fully piped out to the client.
+				resourceQueue.push(task, callback);
 			});
 		};
 

--- a/source/index.js
+++ b/source/index.js
@@ -2,6 +2,7 @@ var url = require('url');
 
 var pump = require('pump');
 var extend = require('extend');
+var async = require('async');
 
 var JsonStream = require('./json');
 var NullifyStream = require('./nullify');
@@ -68,20 +69,26 @@ var fetchBare = function(request, response) {
 	return nullify;
 };
 
-var create = function(options, callback) {
-	if(!callback && typeof options === 'function') {
-		callback = options;
+var endStream = function (jsonStream, error) {
+	jsonStream.writeObject('_error', error);
+	jsonStream.end();
+};
+
+var create = function(options, prefetch) {
+	if(!prefetch && typeof options === 'function') {
+		prefetch = options;
 		options = {};
 	}
 
-	options = options || {};
 
+	options = options || {};
 	var ignore = options.ignore || [];
 	var headers = options.headers !== undefined ? options.headers : true;
+	var concurrency = options.concurrency || 1; // Defaults to sequential fetching
 
 	var fetch = headers ? fetchWithHeaders : fetchBare;
 
-	callback = callback || noopCallback;
+	prefetch = prefetch || noopCallback;
 
 	return function(request, response, next) {
 		var app = request.app;
@@ -95,41 +102,65 @@ var create = function(options, callback) {
 
 		pump(json, response);
 
-		(function loop() {
-			var key = keys.pop();
+		// Exit early if there is nothing to fetch.
+		if(keys.length === 0) {
+			return endStream(json, error);
+		}
 
-			if(!key) {
-				json.writeObject('_error', error);
-				return json.end();
-			}
-
-			var messages = createMessages(request, query[key]);
-
-			var write = function(prevent) {
-				if(prevent) {
-					return loop();
-				}
-
-				var resource = fetch(messages.request, messages.response);
-
-				pump(resource, json.createObjectStream(key), function(err) {
-					if(err) {
-						return json.destroy();
-					}
-					if(!(/2\d\d/).test(messages.response.statusCode)) {
-						error = true;
-					}
-
-					loop();
-				});
-
-				app(messages.request, messages.response, function(err) {
+		// The resource queue processes resource streams sequentially.
+		var resourceQueue = async.queue(function worker(task, callback) {
+			pump(task.resource, json.createObjectStream(task.key), function(err) {
+				if(err) {
 					json.destroy();
-				});
-			};
+					return callback(err);
+				}
+				if(!(/2\d\d/).test(task.response.statusCode)) {
+					error = true;
+				}
+				callback();
+			});
+		}, 1);
 
-			callback(request, messages.request, write);
-		}());
+		// Asynchronously fetch the resource for a key and push the resulting
+		// stream into the resource queue.
+		var fetchResource = function(key, callback) {
+			var messages = createMessages(request, query[key]);
+			process.nextTick(function() {
+				prefetch(request, messages.request, function(prevent) {
+					if (prevent) return callback();
+
+					var resource = fetch(messages.request, messages.response);
+					var task = {
+						resource: resource,
+						request: messages.request,
+						response: messages.response,
+						key: key
+					};
+
+					app(messages.request, messages.response, function() {
+						resourceQueue.kill();
+						json.destroy();
+					});
+
+					// Callback is called once the stream for this resource has
+					// been fully piped out to the client.
+					resourceQueue.push(task, callback);
+				});
+			});
+		};
+
+		// Fire off all requests and push the resulting streams into a queue to
+		// be processed
+		async.eachLimit(keys, concurrency, fetchResource, function(err) {
+			if(resourceQueue.idle()) {
+				endStream(json, error);
+			} else {
+				// Called once all streams have been fully pumped out to the client.
+				resourceQueue.drain = function() {
+					endStream(json, error);
+				};
+			}
+		});
 	};
 };
 

--- a/test/integration/multifetch.options.spec.js
+++ b/test/integration/multifetch.options.spec.js
@@ -275,23 +275,31 @@ describe('multifetch.options', function() {
 				chai.expect(body).to.have.property('_error', false);
 			});
 
-			it('should fetch all resources', function() {
+			it('should fetch api resource', function() {
 				chai.expect(body)
 					.to.have.property('api')
 					.to.have.property('statusCode', 200);
+			});
 
+			it('should fetch user_1 resource', function() {
 				chai.expect(body)
 					.to.have.property('user_1')
 					.to.have.property('statusCode', 200);
+			});
 
+			it('should fetch user_2 resource', function() {
 				chai.expect(body)
 					.to.have.property('user_2')
 					.to.have.property('statusCode', 200);
+			});
 
+			it('should fetch user_3 resource', function() {
 				chai.expect(body)
 					.to.have.property('user_3')
 					.to.have.property('statusCode', 200);
+			});
 
+			it('should fetch user_4 resource', function() {
 				chai.expect(body)
 					.to.have.property('readme')
 					.to.have.property('statusCode', 200);


### PR DESCRIPTION
*Background*: 
My use-case for `multifetch` was to get around Chrome's 6 connections to the same origin limit.
Unfortunately, since most of my sub-queries do fairly heavy database queries, processing each request sequentially was resulting in unacceptable response times compared to creating a separate connection for each query.

So, I added support for routing multiple requests through express concurrently (see README.md additions).
Internally, we use `async.eachLimit` to fire off multiple queries through express at the same time and then queue up the resulting streams which are streamed out to the client sequentially. The next query is only routed through express when the first stream is fully piped out and so on.

By default, I made sure that `multifetch` was still processing requests sequentially so as to maintain backwards compatibility.